### PR TITLE
Content-Type incorrectly set

### DIFF
--- a/lib/rack2aws.rb
+++ b/lib/rack2aws.rb
@@ -87,7 +87,7 @@ module Rack2Aws
     def copy_file(file)
       aws_directory.files.create(:key          => file.key,
                                  :body         => file.body,
-                                 :content_type => file,
+                                 :content_type => file.content_type,
                                  :public       => allow_public)
     end
 

--- a/lib/rack2aws/version.rb
+++ b/lib/rack2aws/version.rb
@@ -1,3 +1,3 @@
 module Rack2Aws
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/rack2aws.gemspec
+++ b/rack2aws.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "commander", "~> 4.4", ">= 4.4.0"
   spec.add_runtime_dependency "fog", "~> 1.37", ">= 1.37.0"
   spec.add_runtime_dependency "artii", "~> 2.1", ">= 2.1.1"
+  spec.add_runtime_dependency "mime-types", "<= 2.99.1"
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.4"


### PR DESCRIPTION
So, upon using this gem, we discovered that the content type was being set to something like `#<Fog::Storage::Rackspace::File:0x007f89c7a78fc0>`, which looks a little off 😉 

I have included the `content_type` call on `file`, so all in all, a pretty straight forward fix.

When trying to look into this, I was getting constant errors about the `mime-type` gem not being installed, which I no amount of uninstalling/reinstalling would solve, but adding it as a runtime dep did the trick, so this might fix the problem for anyone else down the line. It's set the the highest version `fog` supports.

I'm glad I saw this popup on Twitter all those months ago, but hiarlously could use this merged in if you're happy with it ASAP, as I'm in the middle of a site migration.

Cheers.
